### PR TITLE
Create Test It LAB ISO17025 COA

### DIFF
--- a/src/bika/coa/reports/Test It LAB ISO17025 COA
+++ b/src/bika/coa/reports/Test It LAB ISO17025 COA
@@ -1,0 +1,632 @@
+<tal:report
+  i18n:domain="bika.coa"
+  define="collection view/collection;
+          laboratory view/laboratory;
+          coa_num view/get_coa_number;
+          reporter view/current_user;
+          accredited_symbol string:★;
+          outofrange_symbol string:⚠;
+          footer python:view.get_footer_text();
+          report_options python:options.get('report_options', {});
+          attachments_per_row python:int(report_options.get('attachments_per_row', 2));
+          attachments_per_row python:attachments_per_row<1 and 1 or attachments_per_row;
+          page_width options/page_width|nothing;
+          page_height options/page_height|nothing;
+          content_width options/content_width|nothing;
+          content_height options/content_height|nothing;
+          pages python:view.get_pages(options);
+          report_images python:view.get_report_images();
+          styles python:view.get_coa_styles();">
+
+  <!-- Custom Report Controls -->
+  <div id="controls" class="noprint">
+    <div i18n:translate="" class="text-secondary mb-2">Custom Report Options</div>
+    <!-- Attachments per row -->
+    <div class="mb-3">
+      <div class="input-group">
+        <div class="input-group-prepend">
+          <label class="input-group-text" for="attachments_per_row" i18n:translate="">
+            Attachments per Row
+          </label>
+        </div>
+        <input tal:attributes="value attachments_per_row"
+               type="number"
+               class="form-control"
+               name="attachments_per_row"
+               min="1"/>
+      </div>
+      <small class="form-text text-muted" i18n:translate="">
+        Number of attachments rendered within one row per Analysis Request
+      </small>
+    </div>
+  </div>
+
+  <script type="text/javascript">
+   console.info("######################################################################");
+   window.options = "<tal:t replace='options'/>";
+   console.log(window.options);
+   console.info("######################################################################");
+  </script>
+
+  <tal:css>
+    <style type="text/css">
+     .report * { font: 9pt; }
+     .report h1 { font-size: 140%; }
+     .report h2 { font-size: 120%; }
+     .report h3 { font-size: 110%; }
+     .report { font-family: TitilliumText22L-Regular; }
+     .report .font-size-140 { font-size: 140%; }
+     .report .font-size-120 { font-size: 120%; }
+     .report .font-size-100 { font-size: 100%; }
+     .report .colon-after:after { content: ":"; }
+     .report address { margin: 1rem 0; }
+     .report table.noborder td, .report table.noborder th { border: none; }
+     .report table.nopadding td { padding: 0; }
+     .report table td.label { padding-right: 0.3rem; font-weight: bold; }
+     .report table.range-table td { padding: 0 0.3rem 0 0; border: none; }
+     .report .section-header h1 { font-size: 175%; }
+     .report .section-header img.logo { max-height: 200px; margin-bottom: 10px }
+     .report .barcode-hri { margin-top: -0.25em; font-size: 8pt; }
+     .report .section-footer table td { border: none; }
+     .report .section-footer {
+       position: fixed;
+       left: -20mm;
+       bottom: -20mm;
+       margin-left: 20mm;
+       margin-top: 10mm;
+       height: 20mm;
+       width: 100%;
+       text-align: left;
+       font-size: 9pt;
+     }
+     .report .section-footer #footer-line {
+       width: 100%;
+       height: 2mm;
+       border-top: 1px solid black;
+     }
+
+     <tal:block condition="python:content_width and content_height">
+     <tal:block condition="python:all([content_width, content_height])"
+                   define="cw python:float(content_width);
+                           ch python:float(content_height);">
+     /* Ensure that the images stay within the borders */
+     .report .section-attachments img {
+       max-width: <tal:t replace="python:'{:.2f}mm'.format(cw / attachments_per_row)"/>;
+       max-height: <tal:t replace="python:'{:.2f}mm'.format(ch * 0.75)"/>;
+     }
+     .report .section-resultsinterpretation img {
+       max-width: <tal:t replace="python:'{:.2f}mm'.format(cw)"/>;
+       max-height: <tal:t replace="python:'{:.2f}mm'.format(ch * 0.75)"/>;
+     }
+     </tal:block>
+     @page {
+       @bottom-right {
+         vertical-align: bottom;
+         margin-top: 2mm;
+         font-size: 9pt;
+         content: "<tal:t i18n:translate=''>Page</tal:t> " counter(page) " <tal:t i18n:translate=''>of</tal:t> " counter(pages);
+       }
+     }
+    </style>
+  </tal:css>
+  
+<!-- HEADER -->
+  <tal:render condition="python:len(collection)>0"
+              define="primarymodel python:collection[0];">
+
+<!--CoA Block CoA Block CoA Block CoA Block-->
+ <div style="background-color:white;color:black;padding:5px;border:1px solid black;text-align: center;no-gutters;">
+  <div>Certificate of Analysis<strong name='coa_num' tal:content="python: coa_num"/></div>
+ </div>
+<!-- /CoA Block CoA Block CoA Block CoA Block -->
+
+<div style="background-color:white;color:black;padding:5px;border-bottom:1px solid black;no-gutters;">
+<table style="width:100%;">
+  <tr>
+
+<!-- client detals -->
+    <td>
+     <div style="text-align:left;">
+      <tal:render condition="python:len(collection)>0"
+              define="primarymodel python:collection[0];">        
+                  <tal:by_client repeat="client python:view.group_items_by('Client', collection)">
+                      <div tal:content="client/Name"/>
+                  </tal:by_client>
+
+         <tal:by_contact repeat="contact python:view.group_items_by('Contact', collection)">
+          <div tal:content="contact/Fullname"/>
+         </tal:by_contact>
+
+         <tal:by_client repeat="client python:view.group_items_by('Client', collection)">
+          <div tal:content="client/PhysicalAddress/address"/>
+          <div tal:content="client/PhysicalAddress/city"/>
+          <div tal:content="client/PhysicalAddress/zip"/>
+          <div tal:content="client/PhysicalAddress/state"/>
+          <div tal:content="client/PhysicalAddress/country"/>
+         </tal:by_client>
+
+         <tal:by_contact repeat="contact python:view.group_items_by('Contact', collection)">
+          <div tal:content="contact/EmailAddress"/>
+         </tal:by_contact>
+
+          <tal:by_client repeat="client python:view.group_items_by('Client', collection)">
+           <div tal:content="client/Phone"/>
+          </tal:by_client>
+         
+       <div/>
+      </tal:render>
+    </td>
+<!--/ client details-->
+
+<!-- LOGO BLOCK -->
+
+    <td>
+        <div>
+        <img class="logo image-fluid" style="object-fit:contain;" 
+                 tal:attributes="src python:view.get_toolbar_logo();style styles/logo_styles"/>
+       </div>
+    </td>
+
+<!-- /LOGO BLOCK -->
+
+<!-- Adress and accreditation block -->
+     <td>
+     <div style="text-align: left">
+              <div class="lab-title font-weight-bold">
+                <div tal:replace="laboratory/title|nothing"/>
+              </div>
+              <div class="lab-address">
+                <div class="lab-street">
+                <div tal:replace="laboratory/PostalAddress/address|nothing"></div>
+              </div>
+              <div class="lab-city">
+                <div tal:replace="laboratory/PostalAddress/city|nothing"></div>
+              </div>
+              <div class="lab-zip">
+                <div tal:replace="laboratory/PostalAddress/zip|nothing"></div>
+              </div>
+              <div class="lab-state">
+                <div tal:replace="laboratory/PostalAddress/state|nothing"></div>
+              </div>
+              <div class="lab-country">
+                  <div tal:replace="laboratory/PostalAddress/country|nothing"></div>
+              </div>
+     </div>
+     <div class="accreditation-logo" style="align:left"
+                 tal:define="accredited laboratory/LaboratoryAccredited;
+                             accreditation_logo laboratory/AccreditationBodyLogo;"
+                 tal:condition="accredited">
+              <img class="img-fluid"
+                   tal:condition="accreditation_logo"
+                   tal:attributes="src accreditation_logo/absolute_url;style styles/ac_styles"/>
+              <img class="img-fluid"
+                   tal:condition="not:accreditation_logo"
+                   tal:attributes="src python:view.get_resource_url('AccreditationBodyLogo.png', prefix='bika.lims.images');style styles/ac_styles"/>
+     </div>
+     </td>
+</tr>
+</table>
+</div>
+</tal:render>
+<!-- /Adress and accreditation block -->
+  <!-- TEST IT LAB COA DETALS -->
+      <tal:render condition="python:len(collection)>0"
+              define="primarymodel python:collection[0];">  
+<div style="background-color:white;color:black;padding:5px;">
+<div> <strong> Important documents and information </strong> </div> 
+<br>
+<div style="text-align: justify">
+<ul>
+<li>Laboratory activities are performed at the laboratory’s permanent facilities unless otherwise indicated</li>
+<li>Results apply only to the sample as received and the items tested</li>
+<li>Hold time and temperature after sampling may affect the validity of results for QM No. 7.2/TM-01 and QM No. 7.2/TM-02</li>
+<li>Samples are retained for 30 days from the date of reporting where applicable</li>
+<li>Reports shall not be reproduced except in full without approval of the laboratory</li>
+<li>Statement of conformity
+The measurement uncertainty and test results relate only to the samples received and tested by the laboratory
+Uncertainty of measurement is available on request for all methods included in the SANAS Schedule of Accreditation
+The reported expanded uncertainty is based on a standard uncertainty multiplied by a coverage factor of k = 2, 
+providing a level of confidence of approximately 95%
+The binary simple acceptance decision rule is applied (QM No. 7.8/R-02 & ILAC G8)</li>
+<li>Results and information may be disclosed during routine assessments and audits</li>
+<li>We respect your privacy and take the protection of personal information very seriously (QM No. 5/R-06)</li>
+<li>Our Terms and Conditions are available (QM No. 5/R-08) or visit our website for a copy of our <a href="https://www.testit-labs.co.za/terms-conditions/">Terms and Conditions</a></li>
+<li>*Methods are included in this laboratory scope of accreditation
+</li>
+<li>  <tal:render condition="python:True"
+              define="laboratory python:view.laboratory;">
+        <div class="discreeter-outofrange">
+          <span class="outofrange text-danger">
+              <img tal:attributes="src python:report_images['outofrange_symbol_url']"/>
+          </span>
+          <span i18n:translate="">Result out of client specified range.</span>
+        </div>
+</li>
+<li>We welcome your feedback which you can submit via our website, by email, WhatsApp or in person</li>
+<li>Result Query: <a href="francois@testit-labs.co.za">Francois le Roux</a> Financial: <a href="sunet@testit-labs.co.za">Sunet van Biljon</a>Complaints: <a href="elsabe@testit-labs.co.za">Elsabe Botes</a> </li>
+</ul>
+</div>
+<div> <strong>Date Published :</strong>  <span tal:content="python:view.to_localized_time(primarymodel.DatePublished or view.timestamp)"> </div> 
+             
+<div>  <strong> Report authorizided by technical signatory :</strong> <span tal:content="reporter/fullname|reporter/username"/>
+                    <tal:email tal:condition="reporter/email|nothing"
+                               tal:define="email reporter/email|nothing">
+                      (<a tal:content="email"
+                          tal:attributes="href string:mailto:${email}"></a>)
+                    </tal:email>
+   
+</div>
+<br>
+<div> <strong>Signature :</strong> </div>
+<br>
+
+</div>
+      <div class="clearfix"></div>
+<p style="page-break-after: always;"></p>
+
+</tal:render>
+
+  <!-- ALERTS -->
+  <tal:render condition="python:True">
+    <div class="row section-alerts no-gutters">
+      <div class="w-100">
+        <tal:model repeat="model collection">
+          <div class="alert alert-danger" tal:condition="model/is_invalid">
+            <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
+            <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
+            <tal:invalidreport tal:define="child model/Retest"
+                               tal:condition="child">
+              <span i18n:translate="">This Analysis request has been replaced by</span>
+              <a tal:attributes="href child/absolute_url"
+                 tal:content="child/getId"></a>
+            </tal:invalidreport>
+          </div>
+          <div class="alert alert-info" tal:condition="model/is_provisional">
+            <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
+            <div i18n:translate="">Provisional report</div>
+          </div>
+        </tal:model>
+      </div>
+    </div>
+  </tal:render>
+
+  <!-- RESULTS -->
+  <tal:render condition="python:True"
+              define="analyses_by_poc python:view.get_analyses_by_poc(collection);
+                      categories_by_poc python:view.get_categories_by_poc(collection)">
+                      
+
+
+                      
+    <div class="row section-results no-gutters">
+      <div class="w-100">
+        <h1 i18n:translate="">Results</h1>
+
+        <tal:page tal:repeat="page pages">
+        <!-- Point of Captures -->
+        <tal:poc tal:repeat="poc analyses_by_poc">
+          
+
+          <!-- Results table per PoC -->
+          <table class="table table-sm table-condensed small">
+            <thead>
+              <tr>
+                <th>Sample ID</th>
+                <th></th>
+                <th></th>
+                <tal:ar repeat="model page">
+                  <th colspan="2" class="font-weight-normal">
+                    <div class="text-primary text-left"
+                         tal:content="model/Title"/>
+                  </th>
+                </tal:ar>
+              </tr>
+              <tr>
+                <th>
+                    <div class="text-left">Sample Type</div>
+                    <hr style=" margin:2px;" />
+                    <div class="text-left">Sample Point</div>
+                    <hr style=" margin:2px;" />
+                    <div class="text-left">Date/Time Sampled</div> 
+                    <hr style=" margin:2px;" />
+                    <div class="text-left">Date/Time Received</div>
+                    <hr style=" margin:2px;" />
+                    <div class="text-left">Date Verified</div>
+                    <hr style=" margin:2px;" />
+                    <div class="text-left">Condition</div>
+                    <hr style=" margin:2px;" />
+                    <div class="text-left">Specification</div>
+                    <hr style=" margin:2px;" />
+                </th>
+                <th></th>
+                <th></th>
+                <tal:ar repeat="model page">
+                  <th colspan="2" class="font-weight-normal text-left">
+                    <div class="text-left"
+                         tal:content="python:model.SampleTypeTitle or '-'"/>
+                         <hr style=" margin:2px;" />
+                    <div class="text-left"
+                         tal:content="python:model.SamplePointTitle or '-'"/>
+                         <hr style=" margin:2px;" />
+                    <div class="text-left"
+                         tal:content="python:model.DateSampled and view.to_localized_time(model.DateSampled) or '-'"></div>
+                         <hr style=" margin:2px;" />
+                    <div class="text-left"
+                         tal:content="python:model.DateReceived and view.to_localized_time(model.DateReceived) or '-'"></div>
+                         <hr style=" margin:2px;" />
+                    <div class="text-left"
+                         tal:content="python:model.getDateVerified() and view.to_localized_date(model.getDateVerified()) or '-'"></div>
+                         <hr style=" margin:2px;" />
+                    <div class="text-left"
+                         tal:content="model/SampleCondition/title|nothing"> 
+                         <hr style=" margin:2px;" />
+                    <div class="text-left"
+                         tal:content="model/Specification/title|nothing"/>
+                         <hr style=" margin:2px;" />
+                  </th>
+                </tal:ar>
+              </tr>
+            </thead>
+            <tbody>
+              <!-- Categories in PoC -->
+              <tal:categories_in_poc tal:repeat="category python:view.sort_items(categories_by_poc.get(poc))">
+                <tr tal:condition="python:view.get_analyses_by(collection, poc=poc, category=category)">
+                   <td class="font-weight-bold table-warning">
+                       <span tal:content="category/Title"/> 
+                   </td> 
+                   <td class="font-weight-bold">Method</td> 
+                   <td class="font-weight-bold">Unit</td> 
+                   <tal:results repeat="model page">
+                       <td class="font-weight-bold text-left" colspan="2">Result</td> 
+                   </tal:results>
+                </tr> 
+
+                <tr tal:define="common_row_data python:view.get_common_row_data(page, poc=poc, category=category)"
+                    tal:repeat="row_data python:common_row_data">
+                  <td class="text-secondary">
+                    <span tal:content="python: row_data[0]"/>
+                  </td>
+                  <td class="text-secondary">
+                    <span tal:content="python: row_data[1]"/>
+                  </td>
+                  <td class="text-secondary">
+                    <span tal:content="python: row_data[2]"/>
+                  </td>
+                  <tal:results repeat="model page">
+                    <tal:analyses tal:define="analyses python:view.get_analyses_by(model, title=row_data[0]);">
+                      <tal:analysis tal:repeat="analysis analyses">
+                        <td class="text-left"
+                        
+                            tal:define="result python:model.get_formatted_result(analysis);
+                                        verified python:analysis.review_state in ['published', 'verified']">
+                          <span class="font-weight-normal"
+                                tal:condition="python:result and verified"
+                                tal:content="structure result" />
+                          <span class="font-weight-normal"
+                                tal:condition="python:result and not verified">-</span>
+                          <span class="font-weight-normal"
+                                tal:condition="not:result"></span>
+                        </td>
+                        <td class="text-left">
+                          <span tal:condition="python:model.is_out_of_range(analysis)"
+                                class="font-weight-normal">
+                            <span class="outofrange text-danger">
+                                  <img tal:attributes="src python:report_images['outofrange_symbol_url']"/>
+                            </span>
+                          </span>
+                        </td>
+                      </tal:analysis>
+                      <tal:analysis condition="not:analyses">
+                        <td></td>
+                        <td></td>
+                      </tal:analysis>
+                    </tal:analyses>
+                  </tal:results>
+                </tr>
+              </tal:categories_in_poc>
+            </tbody>
+          </table>
+        </tal:poc>
+        </tal:page>
+      </div>
+    </div>
+  </tal:render>
+
+  <!--  RESULTS INTERPRETATIONS -->
+  <tal:render condition="python:True">
+    <tal:model repeat="model collection">
+      <div class="row section-resultsinterpretation no-gutters"
+           tal:define="ris python:model.get_resultsinterpretation();
+                       has_ri python:any(map(lambda r: r.get('richtext'), ris));">
+        <div class="" tal:condition="has_ri">
+          <h1 i18n:translate>Results Interpretation for <span tal:replace="model/getId"/></h1>
+          <tal:ri repeat="ri ris">
+            <h2 tal:condition="ri/richtext|nothing" tal:content="ri/title|nothing">Department</h2>
+            <div class="text-info" tal:content="structure ri/richtext|nothing"></div>
+          </tal:ri>
+        </div>
+      </div>
+    </tal:model>
+  </tal:render>
+
+  <div class="text-center">
+ <th>
+  <strong>
+   END OF RESULTS
+  </strong>
+  <HR>
+ </th>
+</div>
+
+  <!-- QC RESULTS -->
+  <!--<tal:render condition="python:True">
+    <tal:model repeat="model collection">
+      <tal:qc define="qcanalyses python:model.getQCAnalyses(['verified', 'published']);">
+        <div class="row section-results no-gutters" tal:condition="qcanalyses">
+          <div class="">
+            <h2 i18n:translate>QC Results for <span tal:replace="model/getId"/></h2>
+            <div>
+              <h1 i18n:translate="">QC Results</h1>
+            </div>
+          </div>
+        </div>
+      </tal:qc>
+    </tal:model>
+  </tal:render> -->
+<!-- Additional Sample Information-->
+  <tal:render condition="python:True">
+      <div class="w-100 row section-results no-gutters" style="margin-top:5mm; no-gutters" tal:condition="python:view.has_additional_info(collection)">
+          <table class="table table-sm table-condensed small noborder w-100">
+            <thead>
+              <tr>
+                <th colspan=2>
+                    <div class="" style="font-weight:normal; font-size:140%;"><h1>Additional Sample Information</h1></div>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+                <tal:model repeat="model collection">
+                    <tr class="font-weight-bold">
+                        <td style="width:30%">
+                          <div class="col-6">Sample ID </div>
+                        </td>
+                        <td style="width:70%">
+                          <div class="col-6" tal:content="model/getId">Sample ID </div>
+                        </td>
+                    </tr>
+                    <tr tal:condition="python:view.has_remarks(collection)">
+                        <td style="width:30%">
+                          <div class="col-12">Sample Remarks </div>
+                        </td>
+                        <td style="width:70%">
+                          <div class="col-12">
+                            <div  tal:repeat="remark model/Remarks">
+                              <span tal:replace="structure remark/content"></span>
+                            </div>
+                          </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan=2>
+                          <div class="col-12">Interpretation</div>
+                        </td>
+                    </tr>
+                    <tr tal:define="ris python:model.get_resultsinterpretation();
+                                   has_ri python:any(map(lambda r: r.get('richtext'), ris));">
+                        <td style="width:30%" tal:condition="has_ri">
+                                  <tal:ri repeat="ri ris">
+                                    <div class="col-12" style="margin-left:2mm"
+                                        tal:condition="ri/richtext|nothing" tal:content="ri/title|nothing">Department
+                                    </div>
+                                  </tal:ri>
+                        </td>
+                        <td style="width:70%" tal:condition="has_ri">
+                          <!--  RESULTS INTERPRETATIONS -->
+                                <div class="" tal:condition="has_ri">
+                                  <tal:ri repeat="ri ris">
+                                    <div class="col-12" tal:content="structure ri/richtext|nothing"></div>
+                                    <div class="clearfix"></div>
+                                  </tal:ri>
+                                </div>
+                        </td>
+                    </tr>
+                </tal:model>
+            </tbody>
+          </table>
+      </div>
+      <div class="clearfix"></div>
+  </tal:render>
+  <!-- /Additional Sample Information-->
+
+  <!-- ATTACHMENTS -->
+  <tal:render condition="python:True">
+    <div class="row section-attachments no-gutters">
+      <tal:model repeat="model collection">
+        <tal:attachment tal:define="attachments python:model.get_sorted_attachments('r');">
+          <h2 i18n:translate=""
+              tal:condition="attachments">
+            Attachments for <span tal:replace="model/getId"/>
+          </h2>
+          <table class="table w-100" tal:condition="attachments">
+            <colgroup tal:condition="python:len(attachments) > 1">
+              <col tal:repeat="col python:range(attachments_per_row)"
+                   tal:attributes="style python:'width:{}%'.format(100/attachments_per_row)">
+            </colgroup>
+            <tr tal:repeat="chunk python:view.group_into_chunks(attachments, attachments_per_row)">
+              <td class="align-bottom"
+                  style="border:none;padding-left:0;"
+                  tal:repeat="attachment chunk">
+                <figure class="figure">
+                  <img class="figure-img img-fluid"
+                       tal:attributes="src string:${attachment/absolute_url}/AttachmentFile;"/>
+                  <figcaption class="figure-caption pt-2">
+                    <div class="att_for">
+                      <span i18n:translate="">Attachment for</span>
+                      <span tal:content="attachment/getTextTitle|model/getId"/>
+                    </div>
+                    <div class="att_keys">
+                      <span tal:content="attachment/AttachmentKeys"/>
+                    </div>
+                    <div class="att_filename">
+                      <span i18n:translate="">Filename:</span>
+                      <span tal:content="attachment/AttachmentFile/filename"/>
+                    </div>
+                  </figcaption>
+                </figure>
+              </td>
+            </tr>
+          </table>
+        </tal:attachment>
+      </tal:model>
+    </div>
+  </tal:render>
+
+  <!-- CUSTOM FOOTER -->
+  <tal:render condition="python:footer">
+    <div class="row section-footer no-gutters">
+      <!-- Footer Line -->
+      <div id="footer-line"></div>
+      <div tal:replace="structure footer"/>
+    </div>
+  </tal:render>
+
+  <!-- DEFAULT FOOTER -->
+  <tal:render condition="python:not footer"
+              define="laboratory python:view.laboratory;">
+    <div class="row section-footer no-gutters">
+      <!-- Footer Line -->
+      <div id="footer-line"></div>
+      <table class="w-100">
+        <tr>
+          <td>
+            <div>
+              <strong tal:content="laboratory/Name">Lab Name</strong>
+              • <span tal:content="laboratory/PhysicalAddress/address">Lab Street and Number</span>
+              • <span tal:content="laboratory/PhysicalAddress/zip">Lab ZIP</span>
+                <span tal:content="laboratory/PhysicalAddress/city">Lab City</span>
+              • <span tal:content="laboratory/PhysicalAddress/country">Lab Country</span>
+            </div>
+            <div>
+              <span i18n:translate="">Phone</span>:
+              <span tal:content="laboratory/Phone">Lab Phone Number</span>
+              • <a href="#" tal:attributes="href string:mailto:${laboratory/EmailAddress}">
+                <span tal:content="laboratory/EmailAddress">Lab Email</span>
+              </a>
+              • <a href="#" tal:attributes="href laboratory/LabURL">
+                <span tal:content="laboratory/LabURL">Lab URL</span>
+              </a>
+            </div>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </tal:render>
+<div class="text-center">
+ <th>
+  <strong>
+   END OF REPORT
+  </strong>
+  <HR>
+ </th>
+</div>
+</tal:report>


### PR DESCRIPTION
Hi everyone, I have created a new coa template to help with some of the ISO17025 requirements. Changes:
1. Title to display "Certificate of Analysis"
2. Blank space to sign with secure electronic signature as per South African Electronic Communication Transactions Act 25 of 2002. Uploading a signature and pasting does not comply to the standard and will/and have raised non-conformance on our side. It has to be signed with a signature from LawTrust
3. Align results to left for cleaner look
4. Moved page numbering to bottom, this allows labs to edit footer with relevant document numbers and reviewer information as per ISO 17025
5. Removed managers responsible
6. Added first page to act as cover page. Labs should adjust logo and accreditation symbol to fit. Also important document and information would be unique for each lab
7. Sample remarks <p> </p> removed