### PR TITLE
table head not fitting on page

### DIFF
--- a/src/bika/coa/reports/GreenhillDALRRDMulti.pt
+++ b/src/bika/coa/reports/GreenhillDALRRDMulti.pt
@@ -376,6 +376,7 @@
             <tal:poc tal:repeat="poc analyses_by_poc">
 
               <!-- Results table per PoC -->
+              <div class="clearfix"></div> 
               <table class="table table-sm table-condensed small">
                 <thead>
                   <tr>
@@ -528,6 +529,7 @@
                   </tal:categories_in_poc>
                 </tbody>
               </table>
+              <div class="clearfix"></div> 
             </tal:poc>
             </tal:page>
           </div>


### PR DESCRIPTION
Before the fix, the Headers of the table do not show up when the table folds.

![image](https://github.com/bikalims/bika.coa/assets/104898641/2dd7c133-c1c3-40d9-86a7-55975f28bdf2)

After the fix, the table headers show up

![image](https://github.com/bikalims/bika.coa/assets/104898641/4b3efe61-e802-4c9c-8288-81a31877d22b)
