### PR TITLE
reversed order in get pages

### DIFF
--- a/src/bika/coa/reportview.py
+++ b/src/bika/coa/reportview.py
@@ -513,7 +513,9 @@ class MultiReportView(MRV):
         )
         pages = []
         new_page = []
-        for idx, col in enumerate(self.collection):
+        reversed_collection = self.collection[:]
+        reversed_collection.reverse()
+        for idx, col in enumerate(reversed_collection):
             if idx % num_per_page == 0:
                 if len(new_page):
                     pages.append(new_page)


### PR DESCRIPTION
Samples were showing up in reverse order:

![image](https://github.com/bikalims/bika.coa/assets/104898641/8689653f-963c-445d-931f-890f1897bd11)

Samples now appear in ascending order:

![image](https://github.com/bikalims/bika.coa/assets/104898641/c0cd4e0b-d985-4ea5-8994-37a6a188d70c)
