### PR TITLE
Remove sort key requirement

### DIFF
--- a/src/bika/coa/reports/GreenhillDALRRDMulti.pt
+++ b/src/bika/coa/reports/GreenhillDALRRDMulti.pt
@@ -475,7 +475,7 @@
                        </tal:results>
                     </tr> 
 
-                    <tr tal:define="common_row_data python:view.get_common_row_data_green(page, poc=poc, category=category)"
+                    <tr tal:define="common_row_data python:view.get_common_row_data_green_dalrrd(page, poc=poc, category=category)"
                         tal:repeat="row_data python:common_row_data">
                       <td class="text-secondary">
                             <span tal:condition="python: row_data[4]">

--- a/src/bika/coa/reportview.py
+++ b/src/bika/coa/reportview.py
@@ -540,8 +540,36 @@ class MultiReportView(MRV):
             return None
         return earliest_creation_date
 
-
     def get_common_row_data_green(self, collection, poc, category):
+        model = collection[0]
+        analyses = self.get_analyses_by(collection, poc=poc, category=category)
+        common_data = []
+        for analysis in analyses:
+            datum = [analysis.Title(), "-",
+                        model.get_formatted_unit(analysis), "-",
+                        False, False, False, "-"]
+            if analysis.Method:
+                datum[1] = analysis.Method.Title()
+            datum[4] = self.is_analysis_accredited(analysis)
+            datum[5] = self.is_analysis_method_subcontracted(analysis)
+            datum[6] = self.is_analysis_method_savcregistered(analysis)
+            verifier = self.get_verifier_by_analysis(analysis)
+            datum[7] = verifier.get("verifier", "-")
+            instruments = analysis.getAnalysisService().getInstruments()
+            # TODO: Use getInstruments
+            instr_list = []
+            if instruments:
+                for i, instrument in enumerate(instruments):
+                    title = instrument.Title()
+                    if title in instr_list:
+                        continue
+                    instr_list.append(title)
+                datum[3] = " ".join(instr_list)
+            common_data.append(datum)
+        unique_data = self.uniquify_items(common_data)
+        return unique_data
+
+    def get_common_row_data_green_dalrrd(self, collection, poc, category):
         model = collection[0]
         analyses = self.get_analyses_by(collection, poc=poc, category=category)
         common_data = []


### PR DESCRIPTION
Before : GhillDALRRD and GhillMulti both required a sort key on the analysis services.

GHillMulti
![image](https://github.com/bikalims/bika.coa/assets/104898641/e8e2e61a-79a0-46ae-81c7-7c79a3322755)


GHillDALRRD
![image](https://github.com/bikalims/bika.coa/assets/104898641/3c2a7770-7a9c-4d70-a983-e88bb39e5725)



After: Only GhillDALRRD requires a sort key.

GhillMulti
![image](https://github.com/bikalims/bika.coa/assets/104898641/2d7cbeca-bdfd-4df4-819a-0f4d5fd8dcb9)

GHillDALRRD
![image](https://github.com/bikalims/bika.coa/assets/104898641/f2cb0c6d-ef69-4419-aef8-023802fb507f)

