### PR TITLE
ARReport listing change pdf url

### DIFF
--- a/src/bika/coa/browser/listingview/report_listing.py
+++ b/src/bika/coa/browser/listingview/report_listing.py
@@ -66,6 +66,12 @@ class ReportsListingViewAdapter(object):
                 url, value="CSV", target="_blank")
 
         pdf = self.listing.get_pdf(obj)
+        filesize_pdf = self.listing.get_filesize(pdf)
+        if filesize_pdf > 0:
+            url = "{}/at_download/Pdf".format(obj.absolute_url())
+            item["replace"]["PDF"] = get_link(
+                url, value="PDF", target="_blank")
+
         pdf_filename = pdf.filename
         pdf_filename_value = 'Unknown'
         if pdf_filename:


### PR DESCRIPTION
**Before:** 
The PDF report naming was not consistent, it would mostly be named after the main sample when it's supposed to adhere to the idserver.

**After:**
The Reports are now named according to the idserver instead of being named after the main sample.