### PR TITLE
Lims 965 change date formats

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Description of the issue/feature this PR addresses
+
+Linked issue: https://bika.atlassian.net/browse/LIMS-
+
+## Current behavior before PR
+
+## Desired behavior after PR is merged
+
+--
+I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
+and [Plone's Python styleguide][2] standards.
+
+[1]: https://www.python.org/dev/peps/pep-0008
+[2]: https://docs.plone.org/develop/styleguide/python.html

--- a/src/bika/coa/reportview.py
+++ b/src/bika/coa/reportview.py
@@ -179,7 +179,7 @@ class SingleReportView(SRV):
     def get_result_capture_date(self, analysis):
         result = analysis.ResultCaptureDate
         if result:
-            return result.strftime("%d-%b-%Y")
+            return result.strftime("%d-%b-%y")
         return ""
 
     def get_formatted_uncertainty(self, analysis):
@@ -298,7 +298,7 @@ class SingleReportView(SRV):
         return self.to_localized_time(date)[:10]
 
     def get_day_month_year_format(self, date):
-        return date.strftime("%d-%b-%Y")
+        return date.strftime("%d-%b-%y")
 
     def sex_mapping(self, sex):
         sex_dict = {"m": "male", "f":"female"}
@@ -338,8 +338,8 @@ class SingleReportView(SRV):
                 all_dates.append(date_captured)
         all_dates.sort()
         if len(all_dates) > 0:
-            from_date =  all_dates[0].strftime("%d-%b-%Y")
-            to_date =  all_dates[-1].strftime("%d-%b-%Y")
+            from_date =  all_dates[0].strftime("%d-%b-%y")
+            to_date =  all_dates[-1].strftime("%d-%b-%y")
         return [from_date, to_date]
 
     def get_analyst_by_analysis(self, analysis):

--- a/src/bika/coa/reportview.py
+++ b/src/bika/coa/reportview.py
@@ -176,6 +176,12 @@ class SingleReportView(SRV):
             return result.strftime("%Y-%m-%d")
         return ""
 
+    def get_result_capture_date(self, analysis):
+        result = analysis.ResultCaptureDate
+        if result:
+            return result.strftime("%d-%b-%Y")
+        return ""
+
     def get_formatted_uncertainty(self, analysis):
         setup = api.get_setup()
         sciformat = int(setup.getScientificNotationReport())
@@ -291,6 +297,9 @@ class SingleReportView(SRV):
     def to_localized_date(self, date):
         return self.to_localized_time(date)[:10]
 
+    def get_day_month_year_format(self, date):
+        return date.strftime("%d-%b-%Y")
+
     def sex_mapping(self, sex):
         sex_dict = {"m": "male", "f":"female"}
         return sex_dict.get(sex)
@@ -329,8 +338,8 @@ class SingleReportView(SRV):
                 all_dates.append(date_captured)
         all_dates.sort()
         if len(all_dates) > 0:
-            from_date =  self.to_localized_date(all_dates[0])
-            to_date =  self.to_localized_date(all_dates[-1])
+            from_date =  all_dates[0].strftime("%d-%b-%Y")
+            to_date =  all_dates[-1].strftime("%d-%b-%Y")
         return [from_date, to_date]
 
     def get_analyst_by_analysis(self, analysis):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-965

## Current behavior before PR

Date format on cement-coa is dd-mm-yyyy e.g 11-06-2024

## Desired behavior after PR is merged

Date format on cement-coa is dd-Mmm-yyyy  e.g 11-Jun-24

A Pull Request template has been added.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html