### PR TITLE
Lims 1020 changes to water treatment locations coa

### DIFF
--- a/src/bika/coa/reports/HydroChemLocationMulti.pt
+++ b/src/bika/coa/reports/HydroChemLocationMulti.pt
@@ -302,10 +302,6 @@
                     <td>
                       <!-- Laboratory Info -->
                       <address class="laboratory-address text-right">
-                        <div class="lab-supervisor" tal:condition="laboratory/Supervisor">
-                          <span i18n:translate="">Supervisor</span>:
-                          <div tal:replace="laboratory/Supervisor/Fullname|nothing"/>
-                        </div>
                         <div class="lab-address">
                           <div class="lab-street">
                             <div tal:replace="laboratory/PhysicalAddress/address|nothing"></div>
@@ -641,9 +637,9 @@
                          tal:attributes="src string:${manager/absolute_url}/Signature" style="height:75px"/>
                   </div>
                   <div class="font-weight-bold">
-                    <span tal:content="manager/getSalutation"></span>
-                    <span tal:condition="manager/getSalutation">&nbsp;</span>
                     <span tal:content="manager/getFullname"></span>
+                    <span tal:condition="manager/getEmailAddress">&nbsp;</span>
+                    (<span tal:content="manager/getEmailAddress"></span>)
                   </div>
                   <div>
                     <span tal:content="manager/JobTitle"></span>
@@ -681,13 +677,13 @@
             <p i18n:translate=""> <b>NA</b> Not Applicable</p>
           </div>
           <div>
-            <p i18n:translate="">All analyses were carried out at our premises at <span tal:content="laboratory/PhysicalAddress/address|nothing"><span></p>
+            <p i18n:translate="">All analyses were carried out at our premises at <span tal:content="laboratory/PhysicalAddress/address|nothing"></span></p>
           </div>
           <div>
             <p i18n:translate="">Analysis results relate only to the samples tested.</p>
           </div>
+            <p i18n:translate="">Test results are at a <span tal:content="string: ${laboratory/Confidence|nothing}%"></span> confidence level.</p>
           <div>
-            <p i18n:translate="">Test results are at a 95% confidence level.</p>
           </div>
         </div>
     </tal:render>

--- a/src/bika/coa/reports/HydroChemLocationMulti.pt
+++ b/src/bika/coa/reports/HydroChemLocationMulti.pt
@@ -288,7 +288,11 @@
                     <td class="label" i18n:translate="">Email Address</td>
                     <td class="field">
                       <tal:by_contact repeat="contact python:view.group_items_by('Contact', collection)">
-                        <div tal:content="contact/EmailAddress|nothing"/>
+                        <tal:email tal:condition="contact/EmailAddress|nothing"
+                                   tal:define="email contact/EmailAddress|nothing">
+                            <a tal:content="email"
+                               tal:attributes="href string:mailto:${email}"></a>
+                        </tal:email>
                       </tal:by_contact>
                     </td>
                   </tr>
@@ -301,7 +305,7 @@
                   <tr>
                     <td>
                       <!-- Laboratory Info -->
-                      <address class="laboratory-address text-right">
+                      <address style="margin-top: 0;" class="laboratory-address text-right">
                         <div class="lab-address">
                           <div class="lab-street">
                             <div tal:replace="laboratory/PhysicalAddress/address|nothing"></div>
@@ -315,9 +319,6 @@
                           <div class="lab-country">
                             <div tal:replace="laboratory/PhysicalAddress/country|nothing"></div>
                           </div>
-                        </div>
-                        <div class="lab-title">
-                          <div tal:replace="laboratory/EmailAddress|nothing"/>
                         </div>
                         <div class="lab-title">
                           <div tal:replace="laboratory/Phone|nothing"/>
@@ -639,7 +640,13 @@
                   <div class="font-weight-bold">
                     <span tal:content="manager/getFullname"></span>
                     <span tal:condition="manager/getEmailAddress">&nbsp;</span>
-                    (<span tal:content="manager/getEmailAddress"></span>)
+                    (<span>
+                        <tal:email tal:condition="manager/EmailAddress|nothing"
+                                   tal:define="email manager/EmailAddress|nothing">
+                            <a tal:content="email"
+                               tal:attributes="href string:mailto:${email}"></a>
+                        </tal:email>
+                    </span>)
                   </div>
                   <div>
                     <span tal:content="manager/JobTitle"></span>

--- a/src/bika/coa/reports/HydroChemLocationMulti.pt
+++ b/src/bika/coa/reports/HydroChemLocationMulti.pt
@@ -400,7 +400,7 @@
             <div class="table-row">
               <div class="table-header">Sample ID</div>
               <tal:ar repeat="model page">
-                <div class="table-cell font-weight-normal border-out text-primary text-center"
+                <div class="table-cell font-weight-normal border-out text-center"
                       tal:content="model/Title"/>
               </tal:ar>
             </div>

--- a/src/bika/coa/reports/HydroChemLocations2Multi.pt
+++ b/src/bika/coa/reports/HydroChemLocations2Multi.pt
@@ -401,7 +401,7 @@
             <div class="table-row">
               <div class="table-header">Sample ID</div>
               <tal:ar repeat="model page">
-                <div class="table-cell font-weight-normal border-out text-primary text-center"
+                <div class="table-cell font-weight-normal border-out text-center"
                       tal:content="model/Title"/>
               </tal:ar>
             </div>

--- a/src/bika/coa/reports/HydroChemLocations2Multi.pt
+++ b/src/bika/coa/reports/HydroChemLocations2Multi.pt
@@ -301,10 +301,6 @@
                     <td>
                       <!-- Laboratory Info -->
                       <address class="laboratory-address text-right">
-                        <div class="lab-supervisor" tal:condition="laboratory/Supervisor">
-                          <span i18n:translate="">Supervisor</span>:
-                          <div tal:replace="laboratory/Supervisor/Fullname|nothing"/>
-                        </div>
                         <div class="lab-address">
                           <div class="lab-street">
                             <div tal:replace="laboratory/PhysicalAddress/address|nothing"></div>
@@ -634,9 +630,9 @@
                          tal:attributes="src string:${manager/absolute_url}/Signature" style="height:75px"/>
                   </div>
                   <div class="font-weight-bold">
-                    <span tal:content="manager/getSalutation"></span>
-                    <span tal:condition="manager/getSalutation">&nbsp;</span>
                     <span tal:content="manager/getFullname"></span>
+                    <span tal:condition="manager/getEmailAddress">&nbsp;</span>
+                    (<span tal:content="manager/getEmailAddress"></span>)
                   </div>
                   <div>
                     <span tal:content="manager/JobTitle"></span>
@@ -674,13 +670,13 @@
             <p i18n:translate=""> <b>NA</b> Not Applicable</p>
           </div>
           <div>
-            <p i18n:translate="">All analyses were carried out at our premises at <span tal:content="laboratory/PhysicalAddress/address|nothing"><span></p>
+            <p i18n:translate="">All analyses were carried out at our premises at <span tal:content="laboratory/PhysicalAddress/address|nothing"></span></p>
           </div>
           <div>
             <p i18n:translate="">Analysis results relate only to the samples tested.</p>
           </div>
           <div>
-            <p i18n:translate="">Test results are at a 95% confidence level.</p>
+            <p i18n:translate="">Test results are at a <span tal:content="string: ${laboratory/Confidence|nothing}%"></span> confidence level.</p>
           </div>
         </div>
     </tal:render>

--- a/src/bika/coa/reports/HydroChemLocations2Multi.pt
+++ b/src/bika/coa/reports/HydroChemLocations2Multi.pt
@@ -287,7 +287,11 @@
                     <td class="label" i18n:translate="">Email Address</td>
                     <td class="field">
                       <tal:by_contact repeat="contact python:view.group_items_by('Contact', collection)">
-                        <div tal:content="contact/EmailAddress|nothing"/>
+                        <tal:email tal:condition="contact/EmailAddress|nothing"
+                                   tal:define="email contact/EmailAddress|nothing">
+                            <a tal:content="email"
+                               tal:attributes="href string:mailto:${email}"></a>
+                        </tal:email>
                       </tal:by_contact>
                     </td>
                   </tr>
@@ -300,7 +304,7 @@
                   <tr>
                     <td>
                       <!-- Laboratory Info -->
-                      <address class="laboratory-address text-right">
+                      <address style="margin-top: 0;" class="laboratory-address text-right">
                         <div class="lab-address">
                           <div class="lab-street">
                             <div tal:replace="laboratory/PhysicalAddress/address|nothing"></div>
@@ -314,9 +318,6 @@
                           <div class="lab-country">
                             <div tal:replace="laboratory/PhysicalAddress/country|nothing"></div>
                           </div>
-                        </div>
-                        <div class="lab-title">
-                          <div tal:replace="laboratory/EmailAddress|nothing"/>
                         </div>
                         <div class="lab-title">
                           <div tal:replace="laboratory/Phone|nothing"/>
@@ -632,7 +633,13 @@
                   <div class="font-weight-bold">
                     <span tal:content="manager/getFullname"></span>
                     <span tal:condition="manager/getEmailAddress">&nbsp;</span>
-                    (<span tal:content="manager/getEmailAddress"></span>)
+                    (<span>
+                        <tal:email tal:condition="manager/EmailAddress|nothing"
+                                   tal:define="email manager/EmailAddress|nothing">
+                            <a tal:content="email"
+                               tal:attributes="href string:mailto:${email}"></a>
+                        </tal:email>
+                    </span>)
                   </div>
                   <div>
                     <span tal:content="manager/JobTitle"></span>

--- a/src/bika/coa/reportview.py
+++ b/src/bika/coa/reportview.py
@@ -168,7 +168,7 @@ class SingleReportView(SRV):
 
     def get_sampler_fullname(self, model):
         obj = model.instance
-        return obj.getSamplerFullName()
+        return obj.getSampler()
 
     def get_formatted_date(self, analysis):
         result = analysis.ResultCaptureDate


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1020

## Current behavior before PR

- Templates have hyperlinked sample ids and are not uniform.
- Unwanted Supervisor name
- Managers repsonsible view format has not been changed. It  must change from Mr xxxxx  to  yyyy  along with  email address. 
- Access Confidence levels from Laboratory object.

## Desired behavior after PR is merged

- Hyperlinking on sample ids has been removed and templates are uniform.
- Supervisor name removed
- Managers repsonsible view format has been changed to  yyyy  along with  email address. 
- We now access Confidence levels from Laboratory object.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
