### PR TITLE
Moved the Results Interpretations and change the color

### DIFF
--- a/src/bika/coa/reports/HydroChem2025LocationsMulti.pt
+++ b/src/bika/coa/reports/HydroChem2025LocationsMulti.pt
@@ -939,6 +939,24 @@
         </tal:poc>
     </tal:render>
  </tal:page>
+
+  <!--  RESULTS INTERPRETATIONS -->
+  <tal:render condition="python:True">
+    <tal:model repeat="model collection">
+      <div class="row section-resultsinterpretation no-gutters"
+          tal:define="ris python:model.get_resultsinterpretation();
+                      has_ri python:any(map(lambda r: r.get('richtext'), ris));">
+        <div class="" tal:condition="has_ri">
+          <h1 i18n:translate>Results Interpretation for <span tal:replace="model/getId"/></h1>
+          <tal:ri repeat="ri ris">
+            <h2 tal:condition="ri/richtext|nothing" tal:content="ri/title|nothing">Department</h2>
+            <div class="" tal:content="structure ri/richtext|nothing"></div>
+          </tal:ri>
+        </div>
+      </div>
+    </tal:model>
+  </tal:render>
+
  <div class="full-width" style="height: 3px; background-color: #7f2346; margin-bottom: 10px;"></div>
  <div class="page-break"></div>
 <!-- Results end -->
@@ -1052,23 +1070,6 @@
       </div>
     </tal:render>
   <!-- /PAGE HEADER -->
-
-    <!--  RESULTS INTERPRETATIONS -->
-    <tal:render condition="python:True">
-      <tal:model repeat="model collection">
-        <div class="row section-resultsinterpretation no-gutters"
-            tal:define="ris python:model.get_resultsinterpretation();
-                        has_ri python:any(map(lambda r: r.get('richtext'), ris));">
-          <div class="" tal:condition="has_ri">
-            <h1 i18n:translate>Results Interpretation for <span tal:replace="model/getId"/></h1>
-            <tal:ri repeat="ri ris">
-              <h2 tal:condition="ri/richtext|nothing" tal:content="ri/title|nothing">Department</h2>
-              <div class="text-info" tal:content="structure ri/richtext|nothing"></div>
-            </tal:ri>
-          </div>
-        </div>
-      </tal:model>
-    </tal:render>
 
     <!-- REMARKS -->
     <tal:render condition="python:True"

--- a/src/bika/coa/reports/HydroChem2025SystemsMulti.pt
+++ b/src/bika/coa/reports/HydroChem2025SystemsMulti.pt
@@ -939,6 +939,24 @@
         </tal:poc>
     </tal:render>
  </tal:page>
+
+  <!--  RESULTS INTERPRETATIONS -->
+  <tal:render condition="python:True">
+    <tal:model repeat="model collection">
+      <div class="row section-resultsinterpretation no-gutters"
+          tal:define="ris python:model.get_resultsinterpretation();
+                      has_ri python:any(map(lambda r: r.get('richtext'), ris));">
+        <div class="" tal:condition="has_ri">
+          <h1 i18n:translate>Results Interpretation for <span tal:replace="model/getId"/></h1>
+          <tal:ri repeat="ri ris">
+            <h2 tal:condition="ri/richtext|nothing" tal:content="ri/title|nothing">Department</h2>
+            <div class="" tal:content="structure ri/richtext|nothing"></div>
+          </tal:ri>
+        </div>
+      </div>
+    </tal:model>
+  </tal:render>
+
  <div class="full-width" style="height: 3px; background-color: #7f2346; margin-bottom: 10px;"></div>
  <div class="page-break"></div>
 <!-- Results end -->
@@ -1052,23 +1070,6 @@
       </div>
     </tal:render>
   <!-- /PAGE HEADER -->
-
-    <!--  RESULTS INTERPRETATIONS -->
-    <tal:render condition="python:True">
-      <tal:model repeat="model collection">
-        <div class="row section-resultsinterpretation no-gutters"
-            tal:define="ris python:model.get_resultsinterpretation();
-                        has_ri python:any(map(lambda r: r.get('richtext'), ris));">
-          <div class="" tal:condition="has_ri">
-            <h1 i18n:translate>Results Interpretation for <span tal:replace="model/getId"/></h1>
-            <tal:ri repeat="ri ris">
-              <h2 tal:condition="ri/richtext|nothing" tal:content="ri/title|nothing">Department</h2>
-              <div class="text-info" tal:content="structure ri/richtext|nothing"></div>
-            </tal:ri>
-          </div>
-        </div>
-      </tal:model>
-    </tal:render>
 
     <!-- REMARKS -->
     <tal:render condition="python:True"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1379

## Current behavior before PR
Text of Result Interpretations is blue.
Result Interpretations is found on a new page.

## Desired behavior after PR is merged
Text of Result Interpretations should be the same color as the other text.
Result Interpretations should be moved to just after the results section.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
