### PR TITLE
Columns line up in results table for Multi

### DIFF
--- a/src/bika/coa/reports/Multi.pt
+++ b/src/bika/coa/reports/Multi.pt
@@ -14,7 +14,7 @@
           page_height options/page_height|nothing;
           content_width options/content_width|nothing;
           content_height options/content_height|nothing;
-          pages python:view.get_pages(options);
+          pages python:view.get_pages_dynamic(options, 4, 7);
           report_images python:view.get_report_images();
           styles python:view.get_coa_styles();
       ">
@@ -87,6 +87,31 @@
        height: 2mm;
        border-top: 1px solid black;
      }
+
+    .table-row {
+      display: table-row;
+    }
+
+    .table-header {
+      display: table-cell;
+      padding-top : 4px;
+      padding-bottom : 4px;
+      font-weight: bold;
+      border-top: 1px solid #ccc;
+      border-bottom: 1px solid #ccc;
+      width: <tal:t replace="python:'{:.2f}mm'.format(content_width / (len(pages[0]) + 1))"/>;
+      border-right: 1px solid #ccc;
+    }
+
+    .table-cell {
+      display: table-cell;
+      padding-top : 4px;
+      padding-bottom : 4px;
+      border-top: 1px solid #ccc;
+      border-bottom: 1px solid #ccc;
+      width:  <tal:t replace="python:'{:.2f}mm'.format(content_width / (len(pages[0]) + 1))"/>;
+      border-right: 1px solid #ccc;
+    }
 
      <tal:block condition="python:content_width and content_height">
      <tal:block condition="python:all([content_width, content_height])"
@@ -315,162 +340,129 @@
     </div>
   </tal:render>
 
-  <!-- RESULTS -->
-  <tal:render condition="python:True"
-              define="analyses_by_poc python:view.get_analyses_by_poc(collection);
-                      categories_by_poc python:view.get_categories_by_poc(collection)">
-    <div class="row section-results no-gutters">
-      <div class="w-100">
-        <h1 i18n:translate="">Results</h1>
 
-        <tal:page tal:repeat="page pages">
-        <!-- Point of Captures -->
+    <!-- Results start -->
+    <tal:render condition="python:True"
+                define="analyses_by_poc python:view.get_analyses_by_poc(collection);
+                        categories_by_poc python:view.get_categories_by_poc(collection)">
+      <h1 i18n:translate="">Results</h1>
+      <tal:page tal:repeat="page pages">
+      <!-- Point of Captures -->
         <tal:poc tal:repeat="poc analyses_by_poc">
           <h2 tal:content="python:view.points_of_capture.get(poc)"></h2>
-
-          <!-- Results table per PoC -->
-          <table class="table table-sm table-condensed small">
-              <tr>
-                <th colspan="4" style="word-wrap:normal;">Sample ID</th>
-                <tal:ar repeat="model page">
-                  <th colspan="2" class="font-weight-normal">
-                    <div class="text-primary text-center"
-                         tal:content="model/Title"/>
-                  </th>
-                </tal:ar>
-              </tr>
-              <tr class="noborder" style="border:none !important">
-                <tal:ar repeat="model page">
-                  <th colspan="4" tal:condition="python: repeat['model'].start or page.index(model) == 0" class="noborder">
-                        Client Sample ID
-                  </th>
-                  <th colspan="2" class="font-weight-normal text-center noborder">
-                      <div class="text-center" tal:content="python:model.ClientSampleID or '-'"/>
-                  </th>
-                </tal:ar>
-              </tr>
-              <tr class="noborder">
-                <tal:ar repeat="model page">
-                  <th colspan="4" tal:condition="python: repeat['model'].start or page.index(model) == 0" class="noborder">
-                        <div class="text-left">Sample Type</div>
-                  </th>
-                  <th colspan="2" class="font-weight-normal text-center noborder">
-                      <div class="text-center"
-                           tal:content="python:model.SampleTypeTitle or '-'"/>
-                  </th>
-                </tal:ar>
-              </tr>
-              <tr class="noborder">
-                <tal:ar repeat="model page">
-                <th colspan="4" tal:condition="python: repeat['model'].start or page.index(model) == 0" class="noborder">
-                    <div class="text-left">Sample Point</div>
-                </th>
-                 <th colspan="2" class="font-weight-normal text-center noborder">
-                    <div class="text-center"
-                         tal:content="python:model.SamplePointTitle or '-'"/>
-                </th>
-                </tal:ar>
-              </tr>
-              <tr class="noborder">
-                <tal:ar repeat="model page">
-                <th colspan="4" tal:condition="python: repeat['model'].start or page.index(model) == 0" class="noborder">
-                    <div class="text-left">Date Sampled</div>
-                </th>
-                 <th colspan="2" class="font-weight-normal text-center noborder">
-                    <div class="text-center"
-                         tal:content="python:model.DateSampled and view.to_localized_date(model.DateSampled) or '-'"></div>
-                </th>
-                </tal:ar>
-              </tr>
-              <tr class="noborder">
-                <tal:ar repeat="model page">
-                <th colspan="4" tal:condition="python: repeat['model'].start or page.index(model) == 0" class="noborder">
-                    <div class="text-left">Date Received</div>
-                </th>
-                 <th colspan="2" class="font-weight-normal text-center noborder">
-                    <div class="text-center"
-                         tal:content="python:model.DateReceived and view.to_localized_date(model.DateReceived) or '-'"></div>
-                </th>
-                </tal:ar>
-              </tr>
-              <tr>
-                <tal:ar repeat="model page">
-                <th colspan="4" tal:condition="python: repeat['model'].start or page.index(model) == 0" class="noborder">
-                    <div class="text-left">Date Verified</div>
-                </th>
-                 <th colspan="2" class="font-weight-normal text-center" style="border-top: none;">
-                    <div class="text-center"
-                         tal:content="python:model.getDateVerified() and view.to_localized_date(model.getDateVerified()) or '-'"></div>
-                </th>
-                </tal:ar>
-               </tr>
-              <!-- Categories in PoC -->
-              <tal:categories_in_poc tal:repeat="category python:view.sort_items(categories_by_poc.get(poc))">
-                <tr tal:condition="python:view.get_analyses_by(collection, poc=poc, category=category) and view.get_common_row_data(page, poc=poc, category=category)">
-                   <td class="font-weight-bold table-warning">
-                       <span tal:content="category/Title"/> 
-                   </td> 
-                   <td class="font-weight-bold">Method</td> 
-                   <td class="font-weight-bold">Verifier</td>
-                   <td class="font-weight-bold">Unit</td> 
-                   <tal:results repeat="model page">
-                       <td class="font-weight-bold text-center" colspan="2">Result</td> 
-                   </tal:results>
-                </tr> 
-
-                <tr tal:define="common_row_data python:view.get_common_row_data_updated(page, poc=poc, category=category)"
-                    tal:repeat="row_data python:common_row_data">
-                  <td class="text-secondary">
-                    <span tal:condition="python: row_data[4]">
-                      <img tal:attributes="src python:report_images['accredited_symbol_url']"/>
-                    </span>
-                    <span tal:content="python: row_data[0]"/>
-                  </td>
-                  <td class="text-secondary">
-                    <span tal:content="python: row_data[1]"/>
-                  </td>
-                  <td class="text-secondary">
-                    <span tal:content="python: row_data[5]">
-                  </td>
-                  <td class="text-secondary">
-                    <span tal:content="python: row_data[2]"/>
-                  </td>
-                  <tal:results repeat="model page">
-                    <tal:analyses tal:define="analyses python:view.get_analyses_by(model, title=row_data[0]);">
-                      <tal:analysis tal:repeat="analysis analyses">
-                        <td colspan="2" class="text-center"
-                            tal:define="result python:model.get_formatted_result(analysis);
-                                        verified python:analysis.review_state in ['published', 'verified']">
-                          <span class="font-weight-normal"
-                                tal:condition="python:result and verified"
-                                tal:content="structure result" />
-                          <span class="font-weight-normal"
-                                tal:condition="python:result and not verified">-</span>
-                          <span class="font-weight-normal"
-                                tal:condition="not:result"></span>
-                          <span tal:condition="python:model.is_out_of_range(analysis)"
-                                class="font-weight-normal">
-                            <span class="outofrange text-danger">
-                                  <img tal:attributes="src python:report_images['outofrange_symbol_url']"/>
-                            </span>
+          <div class="div-table table-sm table-condensed" style="margin:0;">
+            <div class="table-row">
+              <div class="table-header">Sample ID</div>
+              <tal:ar repeat="model page">
+                <div class="table-cell font-weight-normal text-center"
+                      tal:content="model/Title"/>
+              </tal:ar>
+            </div>
+            <div class="table-row">
+              <div class="table-header">Client Sample ID</div>
+              <tal:ar repeat="model page">
+                <div class="table-cell font-weight-normal text-center"
+                      tal:content="model/ClientSampleID"/>
+              </tal:ar>
+            </div>
+            <div class="table-row">
+              <div class="table-header" class="noborder">Sample Type</div>
+              <tal:ar repeat="model page">
+                <div class="table-cell font-weight-normal text-center"
+                      tal:content="python:model.SampleTypeTitle or '-'"/>
+              </tal:ar>
+            </div>
+            <div class="table-row">
+              <div class="table-header" class="noborder">Sample Point</div>
+              <tal:ar repeat="model page">
+                <div class="table-cell font-weight-normal text-center"
+                      tal:content="python:model.SamplePointTitle or '-'"/>
+              </tal:ar>
+            </div>
+            <div class="table-row">
+              <div class="table-header" class="noborder">Date Sampled</div>
+              <tal:ar repeat="model page">
+                <div class="table-cell font-weight-normal text-center"
+                      tal:content="python:model.DateSampled and view.to_localized_date(model.DateSampled) or '-'"/>
+              </tal:ar>
+            </div>
+            <div class="table-row">
+              <div class="table-header" class="noborder">Date Received</div>
+              <tal:ar repeat="model page">
+                <div class="table-cell font-weight-normal text-center"
+                      tal:content="python:model.DateReceived and view.to_localized_date(model.DateReceived) or '-'"/>
+              </tal:ar>
+            </div>
+            <div class="table-row">
+              <div class="table-header" class="noborder">Date Verified</div>
+              <tal:ar repeat="model page">
+                <div class="table-cell font-weight-normal text-center"
+                      tal:content="python:model.DateVerified and view.to_localized_date(model.DateVerified) or '-'"/>
+              </tal:ar>
+            </div>
+            <tal:categories_in_poc tal:repeat="category python:view.sort_items(categories_by_poc.get(poc))">
+              <div tal:condition="python:view.get_analyses_by(collection, poc=poc, category=category)" class="table-row">
+                <div class="table-header font-weight-bold">
+                  <span tal:content="category/Title"/>
+                </div>
+                <tal:results repeat="model page">
+                  <div class="table-cell font-weight-bold text-center">Result</div>
+                </tal:results>
+              </div>
+              <div class="table-row" tal:define="common_row_data python:view.get_common_row_data_green(page, poc=poc, category=category)"
+                      tal:repeat="row_data python:common_row_data">
+                <div class="table-header text-secondary">
+                  <span tal:condition="python: row_data[4]">
+                    <img tal:attributes="src python:report_images['accredited_symbol_url']"/>
+                  </span>
+                  <span tal:condition="python: row_data[5]">
+                    <img tal:attributes="src python:report_images['subcontracted_symbol_url']"/>
+                  </span>
+                  <span tal:condition="python: row_data[6]">
+                    <img tal:attributes="src python:report_images['savcregistered_symbol_url']"/>
+                  </span>
+                  <span tal:content="python: row_data[0]"/>
+                </div>
+                <!-- Result values -->
+                <tal:results repeat="model page">
+                  <tal:analyses tal:define="analyses python:view.get_analyses_by(model, title=row_data[0]);">
+                    <tal:analysis tal:repeat="analysis analyses">
+                      <div class="table-cell text-center"
+                              tal:define="result python:model.get_formatted_result(analysis);
+                                          verified python:analysis.review_state in ['published', 'verified']">
+                        <span class="font-weight-normal"
+                              tal:condition="python:result and verified"
+                              tal:content="structure result"/>
+                        <span class="font-weight-normal"
+                              tal:condition="python:result and verified"
+                              tal:content="python:model.get_formatted_unit(analysis)"/>
+                        <span class="font-weight-normal"
+                              tal:condition="python:result and not verified">-</span>
+                        <span class="font-weight-normal"
+                              tal:condition="not:result"></span>
+                        <span tal:condition="python:model.is_out_of_range(analysis)"
+                              class="font-weight-normal">
+                          <span class="outofrange text-danger">
+                                <img tal:attributes="src python:report_images['outofrange_symbol_url']"/>
                           </span>
-                        </td>
-                      </tal:analysis>
-                      <tal:analysis condition="not:analyses">
-                        <td></td>
-                        <td></td>
-                      </tal:analysis>
-                    </tal:analyses>
-                  </tal:results>
-                </tr>
-              </tal:categories_in_poc>
-          </table>
-          <div class="clearfix"></div>
+                        </span>
+                      </div>
+                    </tal:analysis>
+                    <tal:analysis condition="not:analyses">
+                      <div class='table-cell'></div>
+                    </tal:analysis>
+                  </tal:analyses>
+                </tal:results>
+              </div>
+            </tal:categories_in_poc>
+          </div>
+          <br />
+          <br />
         </tal:poc>
-        </tal:page>
-      </div>
-    </div>
-  </tal:render>
+      </tal:page>
+    </tal:render>
+
+<!-- Results end -->
 
   <!--  RESULTS INTERPRETATIONS -->
   <tal:render condition="python:True">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1353

## Current behavior before PR

Multi report result columns do not line up.

## Desired behavior after PR is merged

Multi report result columns line up.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
